### PR TITLE
Pipeline for Deepspeed training (up to LLaMA-13B)

### DIFF
--- a/configs/accelerate/zero2-bf16.yaml
+++ b/configs/accelerate/zero2-bf16.yaml
@@ -1,7 +1,6 @@
 compute_environment: LOCAL_MACHINE
 deepspeed_config:
   deepspeed_multinode_launcher: standard
-  gradient_accumulation_steps: 1
   gradient_clipping: 1.0
   offload_optimizer_device: none
   offload_param_device: none

--- a/configs/accelerate/zero3.yaml
+++ b/configs/accelerate/zero3.yaml
@@ -1,11 +1,10 @@
 compute_environment: LOCAL_MACHINE
 deepspeed_config:
   deepspeed_multinode_launcher: standard
-  gradient_accumulation_steps: 1
   gradient_clipping: 1.0
   offload_optimizer_device: none
   offload_param_device: none
-  zero3_init_flag: true
+  zero3_init_flag: false
   zero3_save_16bit_model: true
   zero_stage: 3
 distributed_type: DEEPSPEED

--- a/scripts/accelerate_launch_wrapper.py
+++ b/scripts/accelerate_launch_wrapper.py
@@ -1,0 +1,38 @@
+import os
+import subprocess
+import argparse
+from pathlib import Path
+
+DEFAULT_MASTER_PORT = 29500
+
+path_to_trlx = Path(__file__).parent.parent
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num_processes", type=int, default=4)
+    parser.add_argument("--config_file", type=str, default="trlx/configs/accelerate/zero2-bf16.yaml")
+    parser.add_argument("--gradient_accumulation_steps", type=int, default=1)
+    parser.add_argument("--experiment_file", type=str, default=str(path_to_trlx / "examples" / "ppo_sentiments_llama.py"))
+    parser.add_argument("--mixed_precision", type=str, default="bf16")
+
+    args, extra = parser.parse_known_args()
+
+    slurm_job_id = int(os.getenv("SLURM_ARRAY_JOB_ID", 0))
+    slurm_array_task_id = int(os.getenv("SLURM_ARRAY_TASK_ID", 0))
+    seed = str(slurm_job_id + slurm_array_task_id)
+
+    command = [
+        "accelerate", "launch",
+        "--num_processes", str(args.num_processes),
+        "--main_process_port", str((DEFAULT_MASTER_PORT + slurm_job_id + slurm_array_task_id) % 65000),
+        "--gradient_accumulation_steps", str(args.gradient_accumulation_steps), 
+        "--config_file", args.config_file,
+        "--mixed_precision", args.mixed_precision,
+        args.experiment_file,
+        "--seed", seed,
+        *extra,
+    ]
+
+    print('\n> [accelerate_launch_wrapper.py] Running: ', " ".join(command), '\n')
+
+    subprocess.run(command)

--- a/scripts/slurm_train_deepspeed.sh
+++ b/scripts/slurm_train_deepspeed.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#SBATCH --job-name=trlx
+#SBATCH --nodes=1
+#SBATCH --cpus-per-gpu=10
+#SBATCH --ntasks-per-node=1
+#SBATCH --partition=compute
+#SBATCH --mem=800G
+#SBATCH --output=logs/%x_%j.out
+
+export WANDB__SERVICE_WAIT=300
+source /opt/rh/devtoolset-10/enable
+
+# just pass all the arguments forward
+python "$@"

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,0 +1,34 @@
+import subprocess
+import argparse
+from pathlib import Path
+
+cur_dir = Path(__file__).parent
+path_to_trlx = cur_dir.parent
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num_gpus", type=int, default=4)
+    parser.add_argument("--config_file", type=str, default="trlx/configs/accelerate/zero2-bf16.yaml")
+    parser.add_argument("--num_runs", type=int, default=1)
+    parser.add_argument("--gradient_accumulation_steps", type=int, default=1)
+    parser.add_argument("--experiment_file", type=str, default=str(path_to_trlx / "examples" / "ppo_sentiments_llama.py"))
+
+    args, extra = parser.parse_known_args()
+
+    command = [
+        "sbatch", 
+        "--gpus-per-node", str(args.num_gpus),
+        "--array", f"0-{args.num_runs-1}", 
+        str(cur_dir / "slurm_train_deepspeed.sh"),
+        # python
+        str(cur_dir / "accelerate_launch_wrapper.py"),
+        "--num_processes", str(args.num_gpus),
+        "--gradient_accumulation_steps", str(args.gradient_accumulation_steps), 
+        "--config_file", args.config_file,
+        "--experiment_file", args.experiment_file,
+        *extra,
+    ]
+
+    print('\n> [train.py] Running: ', " ".join(command), '\n')
+
+    subprocess.run(command)


### PR DESCRIPTION
With this PR, we can RL-finetune (a) bigger models (up to LLaMA-13B) on (b) multiple GPUs (more GPUs —> faster). I am using Zero Stage 2 instead Stage 3 by default, as it is faster.

For PPO with 30B/65B models, 8xA100 don't have enough VRAM — we need ~15xA100, which means using two nodes. We have a few options:
* try CPU offloading — it might allow us to use just one node, but will probably be very slow.
* try multi-node training — this should be fairly easy to implement from our current state, and I guess should be faster than CPU offloading, but according to CarperAI is still too slow.
    * wait for CarperAI people to merge the TRLX NEMO branch, which should make multinode training fast.
    * after NEMO merge, the LLaMA weights will need to be converted to the NEMO format. Someone has to write the converter, though — it doesn't exist yet.
* try RL fine-tuning with LoRA — TRLX already supports LoRA, but we need to add support for LLaMA, and benchmark it against full-rank training. 
    * Also, I am not sure how much memory LoRA will actually save us. I'd need to calculate that based on the difference between the number of trainable parameters now (last two layers) and with LoRA, but I'm not sure what the correct formula is for getting the VRAM requirement from parameter count — the one from the DeepSpeed paper turned out wrong for us (it predicted that SFT training of the 30B LLaMA would take >520 GB, but we successfully trained it on 4 GPUs with total VRAM of 320 GB)

I plan to pause on this until the NEMO branch is merged — maybe Carper will implement all the multi-node infrastructure and LLaMA->NEMO model conversion themselves.

Ideas/advice? @tomekkorbak 